### PR TITLE
Fixed `gl.createBuffer is not a function`.

### DIFF
--- a/src/DOM/Element.js
+++ b/src/DOM/Element.js
@@ -39,7 +39,7 @@ class Element extends Node {
     return window.innerHeight;
   }
 
-  getContext(contextType, context) {
+  getContext(contextType, contextOptions, context) {
     const possibleContext = context || global.__context;
     if (contextType != '2d' && possibleContext) {
       return possibleContext;


### PR DESCRIPTION
With this change, I _believe_ `expo-pixi` works again with Expo SDK 32.