### PR TITLE
APIs have moved to separate packages

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,6 +1,9 @@
 import '@expo/browser-polyfill';
 
-import { Constants, Asset, FileSystem, GLView } from 'expo';
+import { Asset } from 'expo-asset'
+import Constants from 'expo-constants'
+import * as FileSystem from 'expo-file-system'
+import { GLView } from 'expo-gl'
 import React from 'react';
 import { View, Text } from 'react-native';
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
   },
   "peerDependencies": {
     "expo": "^32.0.6",
+    "expo-asset": "*",
+    "expo-constants": "*",
     "expo-file-system": "*",
+    "expo-gl": "*",
     "react": "^16.8.6",
     "react-native": "*"
   },

--- a/src/DOM/HTMLImageElement.js
+++ b/src/DOM/HTMLImageElement.js
@@ -1,5 +1,5 @@
 import { Image } from 'react-native';
-import { FileSystem } from 'expo';
+import * as FileSystem from 'expo-file-system';
 const { writeAsStringAsync, documentDirectory } = FileSystem;
 const EncodingType = FileSystem.EncodingType || FileSystem.EncodingTypes;
 


### PR DESCRIPTION
Importing APIs from the "expo" package is deprecated