### PR TITLE
Add HTMLElement class

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ DOM is provided with very low support, these are used for libs like pixi.js that
 class Node
 class Element
 class Document
+class HTMLElement
 class HTMLImageElement
 class Image
 class ImageBitmap

--- a/src/DOM/HTMLElement.js
+++ b/src/DOM/HTMLElement.js
@@ -1,0 +1,3 @@
+import Element from './Element';
+class HTMLElement extends Element {}
+export default HTMLElement;

--- a/src/window.js
+++ b/src/window.js
@@ -4,11 +4,13 @@ import Document from './DOM/Document';
 
 import './performance';
 
+import HTMLElement from './DOM/HTMLElement';
 import HTMLImageElement from './DOM/HTMLImageElement';
 import HTMLCanvasElement from './DOM/HTMLCanvasElement';
 import HTMLVideoElement from './DOM/HTMLVideoElement';
 import CanvasRenderingContext2D from 'expo-2d-context';
 
+global.HTMLElement = global.HTMLElement || HTMLElement;
 global.HTMLImageElement = global.HTMLImageElement || HTMLImageElement;
 global.Image = global.Image || HTMLImageElement;
 global.ImageBitmap = global.ImageBitmap || HTMLImageElement;


### PR DESCRIPTION
Please accept this PR that adds `HTMLElement`.

As `browser-polyfill` is changing the user agent to "chrome", some web compatible packages think they are running in a webbrowser and run code such as `element instanceof HTMLElement` which throws an `Can't find variable: HTMLElement` exception. (for example @react-aria).